### PR TITLE
Add missed arguments to the listener

### DIFF
--- a/knpu/symfony2-dynamic-subdomains.rst
+++ b/knpu/symfony2-dynamic-subdomains.rst
@@ -420,6 +420,8 @@ and tag it so that it's an event listener on the ``kernel.request`` event:
             class: KnpU\QADayBundle\EventListener\CurrentSiteListener
             arguments:
                 - "@site_manager"
+                - "@doctrine.orm.entity_manager"
+                - "%base_host%"
             tags:
                 -
                     name: kernel.event_listener


### PR DESCRIPTION
The `CurrentSiteListener` class constructor has required arguments:

```php
// src/KnpU/QADayBundle/EventListener/CurrentSiteListener.php

public function __construct(SiteManager $siteManager, EntityManager $em, $baseHost)
{
    $this->siteManager = $siteManager;
    $this->em = $em;
    $this->baseHost = $baseHost;
}
```